### PR TITLE
Stabilize preface data test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+log.txt

--- a/examples/hello_http2/lib/hello_http2.ex
+++ b/examples/hello_http2/lib/hello_http2.ex
@@ -9,7 +9,7 @@ defmodule HelloHttp2 do
       8443,
       certfile: certfile,
       keyfile: keyfile,
-      connections: 50
+      connections: 5
     )
   end
 end

--- a/examples/hello_http2/test.sh
+++ b/examples/hello_http2/test.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-trap 'kill $(jobs -pr)' SIGINT SIGTERM EXIT
+trap 'kill -9 $(jobs -pr)' SIGINT SIGTERM EXIT
 
 cd examples/hello_http2
 
 mix deps.get
 mix compile
-mix run --no-halt &
+mix run --no-halt > ../../log.txt &
 
 sleep 2 # wait for the server to start
 echo "Waiting for the server to start"

--- a/lib/http2.ex
+++ b/lib/http2.ex
@@ -21,6 +21,7 @@ defmodule Http2 do
   def init({port, opts}) do
     {:ok, certfile} = Keyword.fetch(opts, :certfile)
     {:ok, keyfile} = Keyword.fetch(opts, :keyfile)
+
     {:ok, listen_socket} = :gen_tcp.listen(port, [:binary, {:packet, 0}, {:active, false}])
 
     children = [

--- a/lib/http2/connection.ex
+++ b/lib/http2/connection.ex
@@ -27,16 +27,25 @@ defmodule Http2.Connection do
   def recv(conn) do
     case :gen_tcp.recv(conn, 0) do
       {:ok, data} ->
-        :gen_tcp.send(conn, response(data))
+        Logger.info "\nReceived #{inspect(data)}"
+
+        r = response(data)
+
+        Logger.info "\nSending back #{inspect(r)}"
+
+        :gen_tcp.send(conn, r)
       {:error, :closed} ->
+        Logger.info "Socker closed"
+
         :ok
     end
   end
 
   # Received connection preface from the client
   # Sending back Settings frame
-  def response(@connection_preface) do
+  def response(@connection_preface <> _rest) do
     # based on https://http2.github.io/http2-spec/#rfc.section.6.5.1
+    Logger.info "Sending back settings frame"
     <<0::24, 4::8, 0::8, 0::1, 0::31>>
   end
 


### PR DESCRIPTION
The first payload from the client can be the preface only:

```
<<80, 82, 73, 32, 42, 32, 72, 84, 84, 80, 47, 50, 46, 48, 13, 10, 13, 10, 83, 77, 13, 10, 13, 10>>
```

or the preface + some additional data, for example:

```
<<80, 82, 73, 32, 42, 32, 72, 84, 84, 80, 47, 50, 46, 48, 13, 10, 13, 10, 83, 77, 13, 10, 13, 10, 0, 0, 6, 4, 0, 0, 0, 0, 0, 0, 4, 0, 0, 255, 255>>
```

The previous implemtatation could only handle exact matches, but the new
one can work with the subset of the data too.

This fix stabilizes the h2spec generic/1 spec.