### PR TITLE
Frames and frame types

### DIFF
--- a/examples/hello_http2/lib/hello_http2.ex
+++ b/examples/hello_http2/lib/hello_http2.ex
@@ -9,7 +9,7 @@ defmodule HelloHttp2 do
       8443,
       certfile: certfile,
       keyfile: keyfile,
-      connections: 5
+      connections: 1000
     )
   end
 end

--- a/lib/http2/frame/continuation.ex
+++ b/lib/http2/frame/continuation.ex
@@ -1,0 +1,3 @@
+defmodule Http2.Frame.Continuation do
+  require Logger
+end

--- a/lib/http2/frame/data.ex
+++ b/lib/http2/frame/data.ex
@@ -1,0 +1,3 @@
+defmodule Http2.Frame.Data do
+  require Logger
+end

--- a/lib/http2/frame/go_away.ex
+++ b/lib/http2/frame/go_away.ex
@@ -1,0 +1,3 @@
+defmodule Http2.Frame.GoAway do
+  require Logger
+end

--- a/lib/http2/frame/header.ex
+++ b/lib/http2/frame/header.ex
@@ -1,0 +1,3 @@
+defmodule Http2.Frame.Header do
+  require Logger
+end

--- a/lib/http2/frame/ping.ex
+++ b/lib/http2/frame/ping.ex
@@ -1,0 +1,3 @@
+defmodule Http2.Frame.Ping do
+  require Logger
+end

--- a/lib/http2/frame/priority.ex
+++ b/lib/http2/frame/priority.ex
@@ -1,0 +1,3 @@
+defmodule Http2.Frame.Priority do
+  require Logger
+end

--- a/lib/http2/frame/push_promise.ex
+++ b/lib/http2/frame/push_promise.ex
@@ -1,0 +1,3 @@
+defmodule Http2.Frame.PushPromise do
+  require Logger
+end

--- a/lib/http2/frame/rst_stream.ex
+++ b/lib/http2/frame/rst_stream.ex
@@ -1,0 +1,3 @@
+defmodule Http2.Frame.RstStream do
+  require Logger
+end

--- a/lib/http2/frame/settings.ex
+++ b/lib/http2/frame/settings.ex
@@ -36,7 +36,7 @@ defmodule Http2.Frame.Settings do
   end
 
   def ack do
-    <<0::24, 4::8, 0::8, 0::1, 0::31>>
+    <<0::24, 4::8, 1::8, 0::1, 0::31>>
   end
 
 end

--- a/lib/http2/frame/window_update.ex
+++ b/lib/http2/frame/window_update.ex
@@ -1,0 +1,3 @@
+defmodule Http2.Frame.WindowUpdate do
+  require Logger
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule Http2.Mixfile do
   def project do
     [app: :http2,
      version: "0.0.1",
-     elixir: "~> 1.2",
+     elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/test/lib/http2/frame_test.exs
+++ b/test/lib/http2/frame_test.exs
@@ -1,0 +1,109 @@
+defmodule Http2.FrameTest do
+  use ExUnit.Case
+  doctest Http2
+
+  describe ".parse" do
+    test "when the data is shorted then 9 octets it returns {nil, data}" do
+      data = << 0, 1, 2, 3, 4, 5, 6, 7>>
+
+      assert byte_size(data) == 8
+      assert Http2.Frame.parse(data) == {nil, data}
+    end
+
+    test "unrecognized header" do
+      frame_type = 11 # incorrect frame type
+      data = << 0::24, frame_type::8, 0::8, 0::1, 0::31 >>
+
+      assert Http2.Frame.parse(data) == {:error, data}
+    end
+
+    test "data frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 0::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :data, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "header frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 1::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :header, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "priority frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 2::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :priority, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "rst_stream frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 3::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :rst_stream, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "settings frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 4::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :settings, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "push promise frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 5::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :push_promise, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "ping frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 6::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :ping, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "go away frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 7::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :go_away, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "window update frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 8::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :window_update, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "continuation frame" do
+      payload = <<1, 2, 3>>
+
+      data = << byte_size(payload)::24, 9::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :continuation, payload: payload, stream_id: 0}, ""}
+    end
+
+    test "extra peyload is returned to the called" do
+      payload = <<1, 2, 3, 5, 6, 7, 8, 9, 10>>
+      len = 3
+
+      data = << len::24, 0::8, 0::8, 0::1, 0::31, payload::binary >>
+
+      assert Http2.Frame.parse(data) == {%Http2.Frame{len: 3, flags: 0, type: :data, payload: <<1, 2, 3>>, stream_id: 0}, <<5, 6, 7, 8, 9, 10>>}
+    end
+  end
+end


### PR DESCRIPTION
The server is now able to distinguish between handshake data and
connection data. The incomming data is storred in a buffer. When
the buffer is filled with data, the frame processor decodes the
frames one by one decoding its lenght, type, flags, stream_id and
payload.

When a frame is constructed, it is sent to the `consume_frame` handler
which pattern matches based on `frame.type`. By default, the answer to
a settings frame is ack `<<0::24, 0::8, 1::8, 0::1, 0::31>>`.

Next step is to decode the header frame and initilizize a new stream
based on the stream id.