### PR TITLE
Annoying Socket timeout

### DIFF
--- a/examples/hello_http2/test.sh
+++ b/examples/hello_http2/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-trap 'kill -9 $(jobs -pr)' SIGINT SIGTERM EXIT
+trap 'kill -15 $(jobs -pr)' SIGINT SIGTERM EXIT
 
 cd examples/hello_http2
 

--- a/lib/http2.ex
+++ b/lib/http2.ex
@@ -24,7 +24,8 @@ defmodule Http2 do
     # document me :)
     tcp_options = [
       :binary,
-      {:packet, 0},
+      {:reuseaddr, true},
+      {:packet, :raw},
       {:active, false}
     ]
 


### PR DESCRIPTION
Today I learned that when a program crashes, linux won't automaticaly
release all the ports associated with that process.

This was super annoying when tring to tests in a short succession, like:

``` bash
make h2spec spec=generic/3.1 ; make h2spec spec=generic/3.1
```

The second call would return 'Address already in use' and I had to wait
up to a minute to run my tests again.

To resolve this, the reuseaddr was added to the socket options. This
article explains the issue in detail:

<http://hea-www.harvard.edu/~fine/Tech/addrinuse.html>