### PR TITLE
Hpack - Read content of the header payload

### DIFF
--- a/examples/hello_http2/mix.lock
+++ b/examples/hello_http2/mix.lock
@@ -1,0 +1,1 @@
+%{"hpack": {:hex, :hpack, "1.0.3", "b27e5c6eca73d031db7597ffc15f805e93dc208cc6902aae30771df1e77dcc97", [], [], "hexpm"}}

--- a/lib/http2/frame/header.ex
+++ b/lib/http2/frame/header.ex
@@ -69,7 +69,7 @@ defmodule Http2.Frame.Header do
   # When set, bit 5 indicates that the Exclusive Flag (E), Stream Dependency, and
   # Weight fields are present; see Section 5.3.
 
-  def decode(frame) do
+  def decode(frame, hpack_table) do
     <<_::1, _::1, priority::1, _::1, padded::1, end_headers::1, _::1, end_stream::1>> = frame.flags
 
     header_block_fragment = if padded == 1 do
@@ -83,7 +83,7 @@ defmodule Http2.Frame.Header do
       end_stream: (end_stream == 1),
       priority: (priority == 1),
       padded: (padded == 1),
-      header_block_fragment: header_block_fragment
+      header_block_fragment: HPack.decode(header_block_fragment, hpack_table)
     }
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,6 @@ defmodule Http2.Mixfile do
   end
 
   defp deps do
-    []
+    [{:hpack, "~> 1.0.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,1 @@
+%{"hpack": {:hex, :hpack, "1.0.3", "b27e5c6eca73d031db7597ffc15f805e93dc208cc6902aae30771df1e77dcc97", [], [], "hexpm"}}

--- a/test/lib/http2/frame/header_test.exs
+++ b/test/lib/http2/frame/header_test.exs
@@ -1,0 +1,44 @@
+defmodule Http2.Frame.HeaderTest do
+  use ExUnit.Case
+  doctest Http2
+
+  describe ".decode" do
+
+    setup do
+      {:ok, hpack_table} = HPack.Table.start_link(1000)
+
+      {:ok, hpack_table: hpack_table}
+    end
+
+    test "decoding the flags", %{ hpack_table: hpack_table } do
+      paylaod = <<130, 134, 132, 65, 138, 8, 157, 92, 11, 129, 112, 220, 121, 166, 153>>
+      flags   = encode_flags(1, 0, 0, 1)
+      frame   = %Http2.Frame{ type: :header, flags: flags, len: 16, payload: paylaod }
+      header  = Http2.Frame.Header.decode(frame, hpack_table)
+
+      assert header.end_stream == true
+      assert header.end_headers == false
+      assert header.padded == false
+      assert header.priority == true
+    end
+
+    test "decoding the payload", %{ hpack_table: hpack_table } do
+      paylaod = <<130, 134, 132, 65, 138, 8, 157, 92, 11, 129, 112, 220, 121, 166, 153>>
+      flags   = encode_flags(0, 0, 1, 0)
+      frame   = %Http2.Frame{ type: :header, flags: flags, len: 16, payload: paylaod }
+      header  = Http2.Frame.Header.decode(frame, hpack_table)
+
+      assert header.header_block_fragment == [
+        {":method", "GET"},
+        {":scheme", "http"},
+        {":path", "/"},
+        {":authority", "127.0.0.1:8443"}
+      ]
+    end
+
+  end
+
+  def encode_flags(priority, padded, end_headers, end_stream) do
+    << 0::1, 0::1, priority::1, 0::1, padded::1, end_headers::1, 0::1, end_stream::1>>
+  end
+end


### PR DESCRIPTION
With hpack we can convert this binary blob:

```
<<130, 134, 132, 65, 138, 8, 157, 92, 11, 129, 112, 220, 121, 166, 153>>
```

into this array of hashes:

```
[
  {":method", "GET"},
  {":scheme", "http"},
  {":path", "/"},
  {":authority", "127.0.0.1:8443"}
]
```

:tada: