### PR TITLE
Serialize header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ start_hello:
 	cd examples/hello_http2 && mix compile
 	cd examples/hello_http2 && mix run --no-halt
 
+# only passing specs
+h2specGreen:
+	bash h2spec.sh generic/1     # creating a http2 connection
+	bash h2spec.sh generic/3.1   # data frames
+	bash h2spec.sh generic/3.2/1 # receiving a header
+
 h2spec:
 	bash h2spec.sh $(spec) || (tail -n 1000 log.txt && false)
 

--- a/lib/http2/connection.ex
+++ b/lib/http2/connection.ex
@@ -102,9 +102,21 @@ defmodule Http2.Connection do
 
   def consume_frame(frame = %Frame{type: :header}, state) do
     header = Http2.Frame.Header.decode(frame, state.hpack_table)
-    Logger.info inspect(frame)
 
+    Logger.info inspect(frame)
     Logger.info "#{inspect(header)}"
+
+    p = HPack.encode(header.header_block_fragment, state.hpack_table)
+
+    response_frame = %Http2.Frame{
+      len: byte_size(p),
+      type: :header,
+      flags: 5, # end headers, end_stream
+      stream_id: frame.stream_id,
+      payload: p
+    }
+
+    respond(Http2.Frame.serialize(response_frame), state)
 
     state
   end

--- a/lib/http2/frame.ex
+++ b/lib/http2/frame.ex
@@ -129,4 +129,28 @@ defmodule Http2.Frame do
     end
   end
 
+  def serialize(frame) do
+    type = case frame.type do
+      :data -> 0
+      :header -> 1
+      :priority -> 2
+      :rst_stream -> 3
+      :settings -> 4
+      :push_promise -> 5
+      :ping -> 6
+      :go_away -> 7
+      :window_update -> 8
+      :continuation -> 9
+    end
+
+    <<
+      frame.len::24,
+      type::8,
+      frame.flags::8,
+      0::1,
+      frame.stream_id::31,
+      frame.payload::binary
+    >>
+  end
+
 end


### PR DESCRIPTION
Minimal implementation to pass `h2spec generic/3.2/1`.

In this pull request, I have also separated tests that are expected to pass from the ones that are not expected to pass. On CI I run only the ones that I expect to pass. 

Previous to this every build was red, and I had no confidence that I can merge the PR because I could have broken something that I thought that it was implemented.