### PR TITLE
Decode header frames that have padding in the payload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ h2specGreen:
 	bash h2spec.sh generic/1     # creating a http2 connection
 	bash h2spec.sh generic/3.1   # data frames
 	bash h2spec.sh generic/3.2/1 # receiving a header
+	bash h2spec.sh generic/3.2/2 # receiving a padded header
 
 h2spec:
 	bash h2spec.sh $(spec) || (tail -n 1000 log.txt && false)

--- a/lib/http2/frame/header.ex
+++ b/lib/http2/frame/header.ex
@@ -73,7 +73,7 @@ defmodule Http2.Frame.Header do
     <<_::1, _::1, priority::1, _::1, padded::1, end_headers::1, _::1, end_stream::1>> = frame.flags
 
     header_block_fragment = if padded == 1 do
-      raise "Not implemented"
+      remove_payload_padding(frame.payload)
     else
       frame.payload
     end
@@ -85,6 +85,16 @@ defmodule Http2.Frame.Header do
       padded: (padded == 1),
       header_block_fragment: HPack.decode(header_block_fragment, hpack_table)
     }
+  end
+
+  defp remove_payload_padding(frame_payload) do
+    <<pad_length::8>> <> padded_payload = frame_payload
+
+    length_without_padding = byte_size(padded_payload) - pad_length
+
+    <<payload::bytes-size(length_without_padding)>> <> _padding = padded_payload
+
+    payload
   end
 
 end

--- a/lib/http2/frame/settings.ex
+++ b/lib/http2/frame/settings.ex
@@ -4,7 +4,7 @@ defmodule Http2.Frame.Settings do
   # length    MUST be 6
   # type      MUST be 4
   # stream_id MUST be 0
-  def parse(<<len::24, 4::8, flags::8, 0::1, 0::31>> <> payload) do
+  def parse(<<len::24, 4::8, _flags::8, 0::1, 0::31>> <> payload) do
     if len / 6 == 0 do
       parse_settings(payload)
     else

--- a/test/lib/http2/frame/header_test.exs
+++ b/test/lib/http2/frame/header_test.exs
@@ -36,6 +36,21 @@ defmodule Http2.Frame.HeaderTest do
       ]
     end
 
+    test "decoding a payload with padding", %{ hpack_table: hpack_table } do
+      # 8 octets of padding
+      paylaod = <<8, 130, 134, 132, 65, 138, 8, 157, 92, 11, 129, 112, 220, 121, 166, 153, 0, 0, 0, 0, 0, 0, 0, 0>>
+      flags   = encode_flags(0, 1, 1, 0) # padded
+      frame   = %Http2.Frame{ type: :header, flags: flags, len: 16, payload: paylaod }
+      header  = Http2.Frame.Header.decode(frame, hpack_table)
+
+      assert header.header_block_fragment == [
+        {":method", "GET"},
+        {":scheme", "http"},
+        {":path", "/"},
+        {":authority", "127.0.0.1:8443"}
+      ]
+    end
+
   end
 
   def encode_flags(priority, padded, end_headers, end_stream) do


### PR DESCRIPTION
If the padding flag is set (0x8) the payload of the header frame
contains additional padding at the end of the payload.

The payload looks like:

```
+---------------+
|Pad Length? (8)|
+-+-------------+-----------------------------------------------+
|                   Header Block Fragment (*)                 ...
+---------------------------------------------------------------+
|                           Padding (*)                       ...
+---------------------------------------------------------------+
```

To handle such payload we need to:

1) read the value of the pad lenght
2) remove the pad lenght field from the payload
3) remove the padding field from the end of the payload

The resulting trimmed payload need to be passed to hpack decode to
get the header values. Example:

```
-- original payload
<<8, 130, 134, 132, 65, 138, 8, 157, 92, 11, 129, 112, 220, 121, 166, 153, 0, 0, 0, 0, 0, 0, 0, 0>>

-- without the pad lenght
<<130, 134, 132, 65, 138, 8, 157, 92, 11, 129, 112, 220, 121, 166, 153, 0, 0, 0, 0, 0, 0, 0, 0>>

-- without the padding
<<130, 134, 132, 65, 138, 8, 157, 92, 11, 129, 112, 220, 121, 166, 153>>

-- hpack decoded
[
  {":method", "GET"},
  {":scheme", "http"},
  {":path", "/"},
  {":authority", "127.0.0.1:8443"}
]
```