### PR TITLE
Parse & respond to PING frames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ h2specGreen:
 	bash h2spec.sh generic/1     # creating a http2 connection
 	bash h2spec.sh generic/3.1   # data frames
 	bash h2spec.sh generic/3.2   # header frames
+	bash h2spec.sh generic/3.5   # ping frames
 
 h2spec:
 	bash h2spec.sh $(spec) || (tail -n 1000 log.txt && false)

--- a/lib/http2/connection.ex
+++ b/lib/http2/connection.ex
@@ -134,6 +134,18 @@ defmodule Http2.Connection do
 
     ping = Http2.Frame.Ping.decode(frame)
 
+    unless ping.flags.ack? do
+      response_frame = %Http2.Frame{
+        len: byte_size(ping.data),
+        type: :ping,
+        flags: 1, # ack
+        stream_id: frame.stream_id,
+        payload: ping.data
+      }
+
+      respond(Http2.Frame.serialize(response_frame), state)
+    end
+
     state
   end
 

--- a/lib/http2/connection.ex
+++ b/lib/http2/connection.ex
@@ -129,6 +129,14 @@ defmodule Http2.Connection do
     state
   end
 
+  def consume_frame(frame = %Frame{type: :ping}, state) do
+    Logger.info "===> ping #{inspect(frame)}"
+
+    ping = Http2.Frame.Ping.decode(frame)
+
+    state
+  end
+
   def consume_frame(frame, state) do
     Logger.info "===> Generic Frame #{inspect(frame)}"
 

--- a/lib/http2/frame/ping.ex
+++ b/lib/http2/frame/ping.ex
@@ -1,3 +1,59 @@
 defmodule Http2.Frame.Ping do
+  #
+  # The PING frame (type=0x6) is a mechanism for measuring a minimal
+  # round-trip time from the sender, as well as determining whether an
+  # idle connection is still functional. PING frames can be sent from
+  # any endpoint.
+  #
+  #  +---------------------------------------------------------------+
+  #  |                                                               |
+  #  |                      Opaque Data (64)                         |
+  #  |                                                               |
+  #  +---------------------------------------------------------------+
+  # Figure 12: PING Payload Format
+  #
+  # In addition to the frame header, PING frames MUST contain 8 octets
+  # of opaque data in the payload. A sender can include any value it
+  # chooses and use those octets in any fashion.
+  #
+  # Receivers of a PING frame that does not include an ACK flag MUST send
+  # a PING frame with the ACK flag set in response, with an identical
+  # payload. PING responses SHOULD be given higher priority than any
+  # other frame.
+  #
+  # The PING frame defines the following flags:
+  #
+  # ACK (0x1):
+  # When set, bit 0 indicates that this PING frame is a PING response.
+  # An endpoint MUST set this flag in PING responses. An endpoint MUST
+  # NOT respond to PING frames containing this flag.
+  #
+  # PING frames are not associated with any individual stream.
+  # If a PING frame is received with a stream identifier field value
+  # other than 0x0, the recipient MUST respond with a connection error
+  # (Section 5.4.1) of type PROTOCOL_ERROR.
+  #
+  # Receipt of a PING frame with a length field value other than 8 MUST
+  # be treated as a connection error (Section 5.4.1) of type
+  # FRAME_SIZE_ERROR.
+
   require Logger
+
+  defmodule Flags do
+    defstruct ack?: false
+
+    def decode(raw_flags) do
+      <<_::7, ack::1>> = raw_flags
+
+      %__MODULE__{ ack?: (ack == 1) }
+    end
+  end
+
+  defstruct flags: nil, data: nil
+
+  def decode(frame) do
+    flags = Flags.decode(frame.flags)
+
+    %__MODULE__{ flags: flags, data: frame.payload }
+  end
 end

--- a/test/lib/http2/frame/ping_test.exs
+++ b/test/lib/http2/frame/ping_test.exs
@@ -1,0 +1,31 @@
+defmodule Http2.Frame.PingTest do
+  use ExUnit.Case
+  doctest Http2
+
+  describe "Flags" do
+    test "decodes ack flag" do
+      assert Http2.Frame.Ping.Flags.decode(<< 0::7, 1::1 >>).ack?
+      refute Http2.Frame.Ping.Flags.decode(<< 0::7, 0::1 >>).ack?
+    end
+  end
+
+  describe ".decode" do
+    test "decode ping frame" do
+      flags = <<0::7, 1::1>>
+      payload = <<1::64>>
+      len = 8
+
+      frame = %Http2.Frame{
+        flags: flags,
+        payload: payload,
+        type: :ping,
+        len: 8
+      }
+
+      ping = Http2.Frame.Ping.decode(frame)
+
+      assert ping.flags.ack?
+      assert ping.data == payload
+    end
+  end
+end


### PR DESCRIPTION
When the connection receives a ping frame, the server MUST
respong with an identical ping frame but with the ack flag
set to true.

The connection should not respond to PING frames with the ack?
flag set to true.