### PR TITLE
Close the connection not the port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,7 @@ start_hello:
 # only passing specs
 h2specGreen:
 	bash h2spec.sh generic/1     # creating a http2 connection
-	bash h2spec.sh generic/3.1   # data frames
-	bash h2spec.sh generic/3.2   # header frames
-	bash h2spec.sh generic/3.5   # ping frames
-	bash h2spec.sh generic/3.8   # go-away frames
+	bash h2spec.sh generic/3     # handling frames
 
 h2spec:
 	bash h2spec.sh $(spec) || (tail -n 1000 log.txt && false)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ start_hello:
 # only passing specs
 h2specGreen:
 	bash h2spec.sh generic/1     # creating a http2 connection
-	bash h2spec.sh generic/3     # handling frames
+	bash h2spec.sh generic/3.1   # data frames
+	bash h2spec.sh generic/3.2   # header frames
+	bash h2spec.sh generic/3.5   # ping frames
+	bash h2spec.sh generic/3.8   # go-away frames
+	bash h2spec.sh generic/3.9   # window update frame
 
 h2spec:
 	bash h2spec.sh $(spec) || (tail -n 1000 log.txt && false)

--- a/lib/http2/connection.ex
+++ b/lib/http2/connection.ex
@@ -42,8 +42,11 @@ defmodule Http2.Connection do
 
       if new_state.state_name != :shutdown do
         :inet.setopts(new_state.conn, active: :once)
+
         {:noreply, new_state}
       else
+        Logger.info "==== Shutdown"
+
         {:stop, :normal, new_state}
       end
     end
@@ -165,7 +168,7 @@ defmodule Http2.Connection do
   def consume_frame(frame = %Frame{type: :go_away}, state) do
     Logger.info "===> go_away #{inspect(frame)}"
 
-    :gen_tcp.close(state.socket)
+    :gen_tcp.close(state.conn)
 
     %{ state | state_name: :shutdown }
   end


### PR DESCRIPTION
The previous implementation used `:get_tcp.close(state.socket)` that
closed the port and in continuation the whole http2 server. This was
a mistake.

Instead, the correct behaviour for go away frame is to use
`:gen_tcp.close(state.conn)` which closes that one connection to the
remote peer, but keeps other connections alive.