### PR TITLE
Decode the content of continuation frames

### DIFF
--- a/lib/http2/connection.ex
+++ b/lib/http2/connection.ex
@@ -173,6 +173,16 @@ defmodule Http2.Connection do
     %{ state | state_name: :shutdown }
   end
 
+  def consume_frame(frame = %Frame{type: :continuation}, state) do
+    Logger.info "===> continuation #{inspect(frame)}"
+
+    continuation = Http2.Frame.Continuation.decode(frame, state.hpack_table)
+
+    # do nothing
+
+    state
+  end
+
   def consume_frame(frame, state) do
     Logger.info "===> Generic Frame #{inspect(frame)}"
 

--- a/lib/http2/frame/continuation.ex
+++ b/lib/http2/frame/continuation.ex
@@ -1,3 +1,45 @@
 defmodule Http2.Frame.Continuation do
   require Logger
+
+  #
+  # Continuation payload:
+  #
+  # +---------------------------------------------------------------+
+  # |                   Header Block Fragment (*)                 ...
+  # +---------------------------------------------------------------+
+  #
+  # The CONTINUATION frame defines the following flag:
+  #
+  # END_HEADERS (0x4):
+  # When set, bit 2 indicates that this frame ends a header
+  # block (Section 4.3).
+  #
+  # If the END_HEADERS bit is not set, this frame MUST be
+  # followed by another CONTINUATION frame. A receiver MUST
+  # treat the receipt of any other type of frame or a frame
+  # on a different stream as a connection error
+  # (Section 5.4.1) of type PROTOCOL_ERROR.
+  #
+
+  require Logger
+
+  defmodule Flags do
+    defstruct end_headers?: false
+
+    def decode(raw_flags) do
+      <<_::5, end_headers::1, _::2>> = raw_flags
+
+      %__MODULE__{ end_headers?: (end_headers == 1) }
+    end
+  end
+
+  defstruct flags: nil, header_block_fragment: nil
+
+  def decode(frame, hpack_table) do
+    %__MODULE__{
+      flags: Flags.decode(frame.flags),
+      header_block_fragment: HPack.decode(frame.payload, hpack_table)
+    }
+  end
+
 end

--- a/test/lib/http2/frame/continuation_test.exs
+++ b/test/lib/http2/frame/continuation_test.exs
@@ -1,0 +1,46 @@
+defmodule Http2.Frame.ContinuationTest do
+  use ExUnit.Case
+  doctest Http2
+
+  describe "Flags" do
+    test "decodes end_headers flag" do
+      assert Http2.Frame.Continuation.Flags.decode(<<0::5, 1::1, 0::2>>).end_headers?
+      refute Http2.Frame.Continuation.Flags.decode(<<0::5, 0::1, 0::2>>).end_headers?
+    end
+  end
+
+  describe ".decode" do
+
+    setup do
+      {:ok, hpack_table} = HPack.Table.start_link(1000)
+
+      {:ok, hpack_table: hpack_table}
+    end
+
+    test "decoding the flags", %{ hpack_table: hpack_table } do
+      paylaod = <<130, 134, 132, 65, 138, 8, 157, 92, 11, 129, 112, 220, 121, 166, 153>>
+      flags   = <<0::5, 1::1, 0::2>>
+
+      frame = %Http2.Frame{type: :continuation, flags: flags, len: 16, payload: paylaod }
+      continuation = Http2.Frame.Header.decode(frame, hpack_table)
+
+      assert continuation.flags.end_headers?
+    end
+
+    test "decoding the payload", %{ hpack_table: hpack_table } do
+      paylaod = <<130, 134, 132, 65, 138, 8, 157, 92, 11, 129, 112, 220, 121, 166, 153>>
+      flags   = <<0::5, 1::1, 0::2>>
+
+      frame = %Http2.Frame{type: :continuation, flags: flags, len: 16, payload: paylaod }
+      continuation = Http2.Frame.Header.decode(frame, hpack_table)
+
+      assert continuation.header_block_fragment == [
+        {":method", "GET"},
+        {":scheme", "http"},
+        {":path", "/"},
+        {":authority", "127.0.0.1:8443"}
+      ]
+    end
+
+  end
+end


### PR DESCRIPTION
Continuation frames contain only one flag: end_headers.

The content of the payload must be decoded with hpack.