### PR TITLE
Decoding data frames

### DIFF
--- a/lib/http2/frame/data.ex
+++ b/lib/http2/frame/data.ex
@@ -1,3 +1,82 @@
 defmodule Http2.Frame.Data do
+  #
+  # DATA frames (type=0x0) convey arbitrary, variable-length sequences of
+  # octets associated with a stream.  One or more DATA frames are used,
+  # for instance, to carry HTTP request or response payloads.
+  #
+  # DATA frames MAY also contain padding.  Padding can be added to DATA
+  # frames to obscure the size of messages.  Padding is a security
+  # feature; see Section 10.7.
+  #
+  #  +---------------+
+  #  |Pad Length? (8)|
+  #  +---------------+-----------------------------------------------+
+  #  |                            Data (*)                         ...
+  #  +---------------------------------------------------------------+
+  #  |                           Padding (*)                       ...
+  #  +---------------------------------------------------------------+
+  #
+  #                     Figure 6: DATA Frame Payload
+  #
+  # The DATA frame contains the following fields:
+  #
+  # Pad Length:  An 8-bit field containing the length of the frame
+  #    padding in units of octets.  This field is conditional (as
+  #    signified by a "?" in the diagram) and is only present if the
+  #    PADDED flag is set.
+  #
+  # Data:  Application data.  The amount of data is the remainder of the
+  #    frame payload after subtracting the length of the other fields
+  #    that are present.
+  #
+  # Padding:  Padding octets that contain no application semantic value.
+  #     Padding octets MUST be set to zero when sending.  A receiver is
+  #     not obligated to verify padding but MAY treat non-zero padding as
+  #     a connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+  #
+  #  The DATA frame defines the following flags:
+  #
+  #  END_STREAM (0x1):  When set, bit 0 indicates that this frame is the
+  #     last that the endpoint will send for the identified stream.
+  #     Setting this flag causes the stream to enter one of the "half-
+  #     closed" states or the "closed" state (Section 5.1).
+  #
+  #  PADDED (0x8):  When set, bit 3 indicates that the Pad Length field
+  #     and any padding that it describes are present.
+  #
+  #  DATA frames MUST be associated with a stream.  If a DATA frame is
+  #  received whose stream identifier field is 0x0, the recipient MUST
+  #  respond with a connection error (Section 5.4.1) of type
+  #  PROTOCOL_ERROR.
+  #
+  #  DATA frames are subject to flow control and can only be sent when a
+  #  stream is in the "open" or "half-closed (remote)" state.  The entire
+  #  DATA frame payload is included in flow control, including the Pad
+  #  Length and Padding fields if present.  If a DATA frame is received
+  #  whose stream is not in "open" or "half-closed (local)" state, the
+  #  recipient MUST respond with a stream error (Section 5.4.2) of type
+  #  STREAM_CLOSED.
+  #
+  #  The total number of padding octets is determined by the value of the
+  #  Pad Length field.  If the length of the padding is the length of the
+  #  frame payload or greater, the recipient MUST treat this as a
+  #  connection error (Section 5.4.1) of type PROTOCOL_ERROR.
+  #
+  #     Note: A frame can be increased in size by one octet by including a
+  #     Pad Length field with a value of zero.
+  #
+
   require Logger
+
+  defmodule Flags do
+    defstruct end_stream?: false, padded?: false
+
+    def decode(raw_flags) do
+      << padded::1, _::6, end_stream::1 >> = raw_flags
+
+      %__MODULE__{ end_stream?: (end_stream == 1), padded?: (padded == 1) }
+    end
+  end
+
+
 end

--- a/lib/http2/frame/data.ex
+++ b/lib/http2/frame/data.ex
@@ -78,5 +78,24 @@ defmodule Http2.Frame.Data do
     end
   end
 
+  defstruct flags: nil, data: nil
+
+  def decode(frame) do
+    flags = Flags.decode(frame.flags)
+
+    data = if flags.padded? do
+      << pad_len::8 >> <> rest = frame.payload
+
+      length_without_padding = byte_size(rest) - pad_len
+
+      <<payload::bytes-size(length_without_padding)>> <> _padding = rest
+
+      payload
+    else
+      frame.payload
+    end
+
+    %__MODULE__{ flags: flags, data: data }
+  end
 
 end

--- a/test/lib/http2/frame/data_test.exs
+++ b/test/lib/http2/frame/data_test.exs
@@ -1,0 +1,36 @@
+defmodule Http2.Frame.DataTest do
+  use ExUnit.Case
+  doctest Http2
+
+  describe "Flags" do
+    test "decodes padded flag" do
+      assert Http2.Frame.Data.Flags.decode(<< 1::1, 0::6, 0::1 >>).padded?
+      refute Http2.Frame.Data.Flags.decode(<< 0::1, 0::6, 0::1 >>).padded?
+    end
+
+    test "decodes end_stream flag" do
+      assert Http2.Frame.Data.Flags.decode(<< 0::1, 0::6, 1::1 >>).end_stream?
+      refute Http2.Frame.Data.Flags.decode(<< 0::1, 0::6, 0::1 >>).end_stream?
+    end
+  end
+
+  describe ".decode" do
+    # test "decode ping frame" do
+    #   flags = <<0::7, 1::1>>
+    #   payload = <<1::64>>
+    #   len = 8
+
+    #   frame = %Http2.Frame{
+    #     flags: flags,
+    #     payload: payload,
+    #     type: :ping,
+    #     len: 8
+    #   }
+
+    #   ping = Http2.Frame.Ping.decode(frame)
+
+    #   assert ping.flags.ack?
+    #   assert ping.data == payload
+    # end
+  end
+end

--- a/test/lib/http2/frame/data_test.exs
+++ b/test/lib/http2/frame/data_test.exs
@@ -15,22 +15,22 @@ defmodule Http2.Frame.DataTest do
   end
 
   describe ".decode" do
-    # test "decode ping frame" do
-    #   flags = <<0::7, 1::1>>
-    #   payload = <<1::64>>
-    #   len = 8
+    test "decoding the payload" do
+      flags   = << 0::1, 0::6, 1::1 >> # not padded
+      payload = "test"
+      frame   = %Http2.Frame{ type: :data, flags: flags, len: 4, payload: payload }
+      header  = Http2.Frame.Data.decode(frame)
 
-    #   frame = %Http2.Frame{
-    #     flags: flags,
-    #     payload: payload,
-    #     type: :ping,
-    #     len: 8
-    #   }
+      assert header.data == "test"
+    end
 
-    #   ping = Http2.Frame.Ping.decode(frame)
+    test "decoding the payload with payload" do
+      flags   = << 1::1, 0::6, 1::1 >> # padded
+      payload = <<4::8>> <> "test" <> <<1, 1, 1, 1>> # for octet padding
+      frame   = %Http2.Frame{ type: :data, flags: flags, len: 9, payload: payload }
+      header  = Http2.Frame.Data.decode(frame)
 
-    #   assert ping.flags.ack?
-    #   assert ping.data == payload
-    # end
+      assert header.data == "test"
+    end
   end
 end


### PR DESCRIPTION
The data frame has two flags:

- padded? (0x08)
- end_stream? (0x01)

If the padded flag is true, the payload of the data frame
contains addition padding that needs to be removed before
processing.

The format of the payload is the following:

```
+---------------+
|Pad Length? (8)|
+---------------+-----------------------------------------------+
|                            Data (*)                         ...
+---------------------------------------------------------------+
|                           Padding (*)                       ...
+---------------------------------------------------------------+
```