### PR TITLE
Decode the rst stream

### DIFF
--- a/lib/http2/frame/rst_stream.ex
+++ b/lib/http2/frame/rst_stream.ex
@@ -1,3 +1,51 @@
 defmodule Http2.Frame.RstStream do
+
+  #
+  # The RST_STREAM frame (type=0x3) allows for immediate termination of a
+  # stream.  RST_STREAM is sent to request cancellation of a stream or to
+  # indicate that an error condition has occurred.
+  #
+  #  +---------------------------------------------------------------+
+  #  |                        Error Code (32)                        |
+  #  +---------------------------------------------------------------+
+  #
+  #                  Figure 9: RST_STREAM Frame Payload
+  #
+  # The RST_STREAM frame contains a single unsigned, 32-bit integer
+  # identifying the error code (Section 7).  The error code indicates why
+  # the stream is being terminated.
+  #
+  # The RST_STREAM frame does not define any flags.
+  #
+  # The RST_STREAM frame fully terminates the referenced stream and
+  # causes it to enter the "closed" state.  After receiving a RST_STREAM
+  # on a stream, the receiver MUST NOT send additional frames for that
+  # stream, with the exception of PRIORITY.  However, after sending the
+  # RST_STREAM, the sending endpoint MUST be prepared to receive and
+  # process additional frames sent on the stream that might have been
+  # sent by the peer prior to the arrival of the RST_STREAM.
+  #
+  # RST_STREAM frames MUST be associated with a stream.  If a RST_STREAM
+  # frame is received with a stream identifier of 0x0, the recipient MUST
+  # treat this as a connection error (Section 5.4.1) of type
+  # PROTOCOL_ERROR.
+  #
+  # RST_STREAM frames MUST NOT be sent for a stream in the "idle" state.
+  # If a RST_STREAM frame identifying an idle stream is received, the
+  # recipient MUST treat this as a connection error (Section 5.4.1) of
+  # type PROTOCOL_ERROR.
+  #
+  # A RST_STREAM frame with a length other than 4 octets MUST be treated
+  # as a connection error (Section 5.4.1) of type FRAME_SIZE_ERROR.
+  #
+
   require Logger
+
+  defstruct error_code: nil
+
+  def decode(frame) do
+    <<error_code::32>> = frame.payload
+
+    %__MODULE__{error_code: error_code}
+  end
 end

--- a/test/lib/http2/frame/rst_stream_test.exs
+++ b/test/lib/http2/frame/rst_stream_test.exs
@@ -1,0 +1,15 @@
+defmodule Http2.Frame.RstStreamTest do
+  use ExUnit.Case
+  doctest Http2
+
+  describe ".decode" do
+    test "decode ping frame" do
+      payload = <<4::32>>
+      frame = %Http2.Frame{ payload: payload }
+
+      rst_stream = Http2.Frame.RstStream.decode(frame)
+
+      assert rst_stream.error_code == 4
+    end
+  end
+end


### PR DESCRIPTION
The RST_STREAM contains only a 32-bit integer that represents
the error code. This frame has no flags.