### PR TITLE
Decoding Push Promise frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pure elixir implementation of the Http2 protocol.
 - [x] Priority
 - [x] RST Stream
 - [ ] Settings
-- [ ] Push Promise
+- [x] Push Promise
 - [x] Ping
 - [x] Go Away
 - [ ] Window Update

--- a/lib/http2/frame/push_promise.ex
+++ b/lib/http2/frame/push_promise.ex
@@ -1,3 +1,70 @@
 defmodule Http2.Frame.PushPromise do
   require Logger
+
+  #
+  # The PUSH_PROMISE frame (type=0x5) is used to notify the peer endpoint
+  # in advance of streams the sender intends to initiate.  The
+  # PUSH_PROMISE frame includes the unsigned 31-bit identifier of the
+  # stream the endpoint plans to create along with a set of headers that
+  # provide additional context for the stream.  Section 8.2 contains a
+  # thorough description of the use of PUSH_PROMISE frames.
+  #
+  #  +---------------+
+  #  |Pad Length? (8)|
+  #  +-+-------------+-----------------------------------------------+
+  #  |R|                  Promised Stream ID (31)                    |
+  #  +-+-----------------------------+-------------------------------+
+  #  |                   Header Block Fragment (*)                 ...
+  #  +---------------------------------------------------------------+
+  #  |                           Padding (*)                       ...
+  #  +---------------------------------------------------------------+
+  #
+  #                Figure 11: PUSH_PROMISE Payload Format
+  #
+  # The PUSH_PROMISE frame payload has the following fields:
+  #
+  # Pad Length:  An 8-bit field containing the length of the frame
+  #    padding in units of octets.  This field is only present if the
+  #    PADDED flag is set.
+  #
+  # R: A single reserved bit.
+  #
+  # Promised Stream ID:  An unsigned 31-bit integer that identifies the
+  #    stream that is reserved by the PUSH_PROMISE.  The promised stream
+  #    identifier MUST be a valid choice for the next stream sent by the
+  #    sender (see "new stream identifier" in Section 5.1.1).
+  #
+  # Header Block Fragment:  A header block fragment (Section 4.3)
+  #    containing request header fields.
+  #
+  # Padding:  Padding octets.
+  #
+  # The PUSH_PROMISE frame defines the following flags:
+  #
+  # END_HEADERS (0x4):  When set, bit 2 indicates that this frame
+  #    contains an entire header block (Section 4.3) and is not followed
+  #    by any CONTINUATION frames.
+  #
+  #    A PUSH_PROMISE frame without the END_HEADERS flag set MUST be
+  #    followed by a CONTINUATION frame for the same stream.  A receiver
+  #    MUST treat the receipt of any other type of frame or a frame on a
+  #    different stream as a connection error (Section 5.4.1) of type
+  #    PROTOCOL_ERROR.
+  #
+  # PADDED (0x8):  When set, bit 3 indicates that the Pad Length field
+  #    and any padding that it describes are present.
+  #
+
+  defmodule Flags do
+    defstruct end_headers?: false, padded?: false
+
+    def decode(raw_flags) do
+      <<padded::1, _::3, end_headers::1, _::3>> = raw_flags
+
+      %__MODULE__{
+        padded?: (padded == 1),
+        end_headers?: (end_headers == 1)
+      }
+    end
+  end
 end

--- a/lib/http2/frame/push_promise.ex
+++ b/lib/http2/frame/push_promise.ex
@@ -68,18 +68,11 @@ defmodule Http2.Frame.PushPromise do
     end
   end
 
-  defstruct flags: nil, promised_stream_id: nil
-  #  +---------------+
-  #  |Pad Length? (8)|
-  #  +-+-------------+-----------------------------------------------+
-  #  |R|                  Promised Stream ID (31)                    |
-  #  +-+-----------------------------+-------------------------------+
-  #  |                   Header Block Fragment (*)                 ...
-  #  +---------------------------------------------------------------+
-  #  |                           Padding (*)                       ...
-  #  +---------------------------------------------------------------+
+  defstruct flags: nil,
+            promised_stream_id: nil,
+            header_block_fragment: nil
 
-  def decode(frame) do
+  def decode(frame, hpack_table) do
     flags = Flags.decode(frame.flags)
 
     data = if flags.padded? do
@@ -92,7 +85,8 @@ defmodule Http2.Frame.PushPromise do
 
     %__MODULE__{
       flags: flags,
-      promised_stream_id: promised_stream_id
+      promised_stream_id: promised_stream_id,
+      header_block_fragment: HPack.decode(header_block_fragment, hpack_table)
     }
   end
 end

--- a/lib/http2/frame/push_promise.ex
+++ b/lib/http2/frame/push_promise.ex
@@ -68,7 +68,7 @@ defmodule Http2.Frame.PushPromise do
     end
   end
 
-  defstruct flags: nil
+  defstruct flags: nil, promised_stream_id: nil
   #  +---------------+
   #  |Pad Length? (8)|
   #  +-+-------------+-----------------------------------------------+
@@ -82,8 +82,17 @@ defmodule Http2.Frame.PushPromise do
   def decode(frame) do
     flags = Flags.decode(frame.flags)
 
+    data = if flags.padded? do
+      Http2.Frame.remove_padding(frame.payload)
+    else
+      frame.payload
+    end
+
+    <<_::1, promised_stream_id::31>> <> header_block_fragment = data
+
     %__MODULE__{
-      flags: flags
+      flags: flags,
+      promised_stream_id: promised_stream_id
     }
   end
 end

--- a/lib/http2/frame/push_promise.ex
+++ b/lib/http2/frame/push_promise.ex
@@ -67,4 +67,23 @@ defmodule Http2.Frame.PushPromise do
       }
     end
   end
+
+  defstruct flags: nil
+  #  +---------------+
+  #  |Pad Length? (8)|
+  #  +-+-------------+-----------------------------------------------+
+  #  |R|                  Promised Stream ID (31)                    |
+  #  +-+-----------------------------+-------------------------------+
+  #  |                   Header Block Fragment (*)                 ...
+  #  +---------------------------------------------------------------+
+  #  |                           Padding (*)                       ...
+  #  +---------------------------------------------------------------+
+
+  def decode(frame) do
+    flags = Flags.decode(frame.flags)
+
+    %__MODULE__{
+      flags: flags
+    }
+  end
 end

--- a/test/lib/http2/frame/push_promise_test.exs
+++ b/test/lib/http2/frame/push_promise_test.exs
@@ -13,4 +13,40 @@ defmodule Http2.Frame.PushPromiseTest do
       refute Http2.Frame.PushPromise.Flags.decode(<<0::4, 0::1, 0::3>>).end_headers?
     end
   end
+
+  describe ".decode" do
+    test "padded payload" do
+      flags = <<1::1, 0::7>> # padded
+      payload = ""
+
+      frame = %Http2.Frame{
+        type: :push_promise,
+        flags: flags,
+        payload: payload,
+        len: byte_size(payload)
+      }
+
+      push_promise = Http2.Frame.PushPromise.decode(frame)
+
+      assert push_promise.flags.padded?
+      refute push_promise.flags.end_headers?
+    end
+
+    test "non-padded payload" do
+      flags = <<0::4, 1::1, 0::3>> # end_headers
+      payload = ""
+
+      frame = %Http2.Frame{
+        type: :push_promise,
+        flags: flags,
+        payload: payload,
+        len: byte_size(payload)
+      }
+
+      push_promise = Http2.Frame.PushPromise.decode(frame)
+
+      refute push_promise.flags.padded?
+      assert push_promise.flags.end_headers?
+    end
+  end
 end

--- a/test/lib/http2/frame/push_promise_test.exs
+++ b/test/lib/http2/frame/push_promise_test.exs
@@ -1,0 +1,16 @@
+defmodule Http2.Frame.PushPromiseTest do
+  use ExUnit.Case
+  doctest Http2
+
+  describe "Flags" do
+    test "decodes padded flag" do
+      assert Http2.Frame.PushPromise.Flags.decode(<< 1::1, 0::7>>).padded?
+      refute Http2.Frame.PushPromise.Flags.decode(<< 0::1, 0::7>>).padded?
+    end
+
+    test "decodes end_stream flag" do
+      assert Http2.Frame.PushPromise.Flags.decode(<<0::4, 1::1, 0::3>>).end_headers?
+      refute Http2.Frame.PushPromise.Flags.decode(<<0::4, 0::1, 0::3>>).end_headers?
+    end
+  end
+end


### PR DESCRIPTION
Payload format:

```
+---------------+
|Pad Length? (8)|
+-+-------------+-----------------------------------------------+
|R|                  Promised Stream ID (31)                    |
+-+-----------------------------+-------------------------------+
|                   Header Block Fragment (*)                 ...
+---------------------------------------------------------------+
|                           Padding (*)                       ...
+---------------------------------------------------------------+
```

Flags:

```
END_HEADERS (0x4):  When set, bit 2 indicates that this frame
   contains an entire header block (Section 4.3) and is not followed
   by any CONTINUATION frames.

   A PUSH_PROMISE frame without the END_HEADERS flag set MUST be
   followed by a CONTINUATION frame for the same stream.  A receiver
   MUST treat the receipt of any other type of frame or a frame on a
   different stream as a connection error (Section 5.4.1) of type
   PROTOCOL_ERROR.

PADDED (0x8):  When set, bit 3 indicates that the Pad Length field
   and any padding that it describes are present.
```