### PR TITLE
Sending headers from a client

### DIFF
--- a/test/integration/hello_world.exs
+++ b/test/integration/hello_world.exs
@@ -58,19 +58,19 @@ defmodule Http2.Integration.HelloWorldTest do
   alias Http2.Connection
 
   test "hello world test", context do
-    {:ok, conn} = Connection.start_link(:client, self(), 'localhost', 8888)
+    {:ok, conn}   = Connection.start_link(:client, self(), 'localhost', 8888)
     {:ok, stream} = Connection.create_stream(conn)
 
     IO.puts "Stream id: #{stream}"
 
-    # headers = [
-    #   ":method": "GET",
-    #   ":path": "/",
-    #   ":scheme": "http",
-    #   "user-agent": "elixir-http2-client/0.0.1"
-    # ]
+    headers = [
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {"user-agent", "elixir-http2-client/0.0.1"}
+    ]
 
-    # :ok = Connection.send_headers(conn, stream, headers: headers, end_stream: true)
+    {:ok, stream} = Connection.send_headers(conn, stream, headers, true, true)
 
     # {:ok, body, headers} = wait_for_response(conn, stream)
 


### PR DESCRIPTION
The client can now send a sync call to the connection
process with the headers, the process can accept it
and encode it with hpack.

Example transcript:

```
00:13:57.241 [info]  ===> [CLIENT] Incomming data "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"

00:13:57.248 [info]  <=== [SERVER] Sending data <<0, 0, 0, 4, 0, 0, 0, 0, 0>>

00:13:57.254 [info]  <=== [CLIENT] Sending data <<0, 0, 23, 1, 5, 0, 0, 0, 1, 130, 132, 134, 122, 146, 45, 6, 242, 107, 22, 157, 41, 172, 75, 18, 131, 22, 164, 176, 5, 192, 184, 127>>
```